### PR TITLE
update run_rin_osu_bw_hpcx_pbs.sh

### DIFF
--- a/apps/health_checks/run_ring_osu_bw_hpcx_pbs.sh
+++ b/apps/health_checks/run_ring_osu_bw_hpcx_pbs.sh
@@ -63,6 +63,6 @@ sort -k3 -n $OUTDIR/osu_bibw_report_$$.log > bibw_report.out
 
 cat bw_report.out | head -n100
 cat latency_report.out | tail -n100
-cat allreduce_report.out | tail -n100
+cat bibw_report.out | tail -n100
 cd $dir
 grep -i error osu_bw_test.* | tee osu_error_report.log


### PR DESCRIPTION
allreduce test has been replaced with bidirectional bandwidth tests but still non-existing allreduce logfiles are reported which causes an error. This was replaced with bibw reports.