### PR TITLE
update build_wrf.sh

### DIFF
--- a/apps/wrf/build_wrf.sh
+++ b/apps/wrf/build_wrf.sh
@@ -98,7 +98,8 @@ function create_links {
     NETCDF_C=$(spack location -i netcdf-c^${MPI_TYPE})
     echo "NETCDF_C=$NETCDF_C"
     ln -sf $NETCDF_C/include/* $NETCDF/include/
-    ln -sf $NETCDF_C/lib/* $NETCDF/lib/
+#    ln -sf $NETCDF_C/lib/* $NETCDF/lib/
+    ln -sf $(ls -p $NETCDF_C/lib/* | grep / ) $NETCDF/lib/
     ln -sf $NETCDF_C/lib/pkgconfig/* $NETCDF/lib/pkgconfig
 }
 


### PR DESCRIPTION
ls -sf $NETCDF_C/lib/* $NETCDF/lib/ gives an error and causes the script to stop, because $NETCDF_C/lib/ contains a directory named pkgconfig which is  also present in  $NETCDF/lib/ and ln -sf can't overwrite directories. 
The proposed change causes ln to only create symbolic links for files and not directories. The next line creates symbolic links for the content of $NETCDF_C/lib/pkgconfig